### PR TITLE
Update GmailCleaner.gs - Allow Thread Count larger than 200

### DIFF
--- a/GmailCleaner.gs
+++ b/GmailCleaner.gs
@@ -23,12 +23,12 @@ SOFTWARE.
 function cleanMailBox() {
     // check the category Gmail added to the thread
     var searches = [
-        '{category:promotions category:Social category:Updates category:Forums} -in:Trash -is:starred -is:important -has:attachment older_than:7d is:unread'
+        '-in:inbox -in:sent -in:chat -in:drafts -is:trash -is:starred -is:important -has:attachment older_than:2y'
     ];
     // creating an array containing all the threads matching the searches above
     var threads = [];
     for (var i = 0; i < searches.length; i++) {
-        var tmp_threads = GmailApp.search(searches[i], 0, 200); // Limiting the search to 200 results but its adjustable to certain extent.  NB: Maximum is 500
+        var tmp_threads = GmailApp.search(searches[i], 0, 500); // Limiting the search to 200 results but its adjustable to certain extent.  NB: Maximum is 500
         threads = threads.concat(
             tmp_threads);
     }
@@ -39,6 +39,7 @@ function cleanMailBox() {
         for (var i = 0; i < threads.length; i++) {
             splitThreads.push(threads[i]);
             if (String(i).endsWith('99') || i == threads.length - 1) {
+                console.info('i is at %d', i); // Trouble-shooting step, can be removed
                 GmailApp.moveThreadsToTrash(splitThreads);
                 console.info('Moved %d threads to trash', splitThreads.length);
                 splitThreads = [];

--- a/GmailCleaner.gs
+++ b/GmailCleaner.gs
@@ -28,7 +28,7 @@ function cleanMailBox() {
     // creating an array containing all the threads matching the searches above
     var threads = [];
     for (var i = 0; i < searches.length; i++) {
-        var tmp_threads = GmailApp.search(searches[i], 0, 200); // Limiting the search to 200 results but its adjustable to certain extent
+        var tmp_threads = GmailApp.search(searches[i], 0, 200); // Limiting the search to 200 results but its adjustable to certain extent.  NB: Maximum is 500
         threads = threads.concat(
             tmp_threads);
     }
@@ -38,7 +38,7 @@ function cleanMailBox() {
         var splitThreads = [];
         for (var i = 0; i < threads.length; i++) {
             splitThreads.push(threads[i]);
-            if (i == 99 || i == threads.length - 1) {
+            if (String(i).endsWith('99') || i == threads.length - 1) {
                 GmailApp.moveThreadsToTrash(splitThreads);
                 console.info('Moved %d threads to trash', splitThreads.length);
                 splitThreads = [];

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,15 +1,19 @@
 # Gmail Cleaner
 
+*Forked from https://github.com/omkar9999/GmailCleaner (Thanks Omar :smiley:) and updated to my preferences and to fix an error with thread counts greater than 200.*
+
 This script will help you delete old emails inside your Gmail Mailbox by moving them to trash.
 It deletes emails based on the Gmail Queries mentioned inside searches.
 The default script will delete the emails that are-
-1) Inside default Gmail Cetegories
-2) Unread
-3) Not starred
-4) Not in Trash
-5) Don't have attachments
-6) Not marked important
-7) Older than 7 days
+1) Not in your inbox (including Google Categories)
+2) Not in Sent Items
+3) Not in Chats
+4) Not in Drafts
+5) Not in Trash
+6) Not starred
+7) Not marked important
+8) Don't have attachments
+9) Older than 2 years
 
 The default filters are kept in place to keep your important emails safe.
 So, please ensure that your important emails don't match all the above criteria.
@@ -47,6 +51,7 @@ with Apps Script, take a look at the following resources:
 ## Authors
 
 * **Omkar Marathe** - *Initial work* - [Omkar](https://github.com/omkar9999/)
+* **Pete Shaw** (Cockney Rhyming Jedi) - *amendments and logic correction* - [Cockney Rhyming Jedi](https://github.com/CockneyRhymingJedi)
 
 ## Support/Contributing
 


### PR DESCRIPTION
Changed logic to account for total threads larger than 200 (otherwise, it errors).  
Added comment to inform of maximum threads allowed by Google (500)